### PR TITLE
Escaped the exports written to the profile file by go installer

### DIFF
--- a/linux_files/setup
+++ b/linux_files/setup
@@ -411,8 +411,8 @@ if (whiptail --title "GO" --yesno "Would you like to download and install the la
     export PATH=$GOPATH/bin:$GOROOT/bin:/usr/local/go/bin:$PATH
     echo "Saving Go environment variables to /etc/profile so they will persist."
     sudo sh -c 'echo "export GOROOT=/usr/local/go" >> /etc/profile'
-    sudo sh -c 'echo "export GOPATH=$HOME/go/" >> /etc/profile'
-    sudo sh -c 'echo "export PATH=$GOPATH/bin:$GOROOT/bin:/usr/local/go/bin:$PATH" >> /etc/profile'
+    sudo sh -c 'echo "export GOPATH=\${HOME}/go/" >> /etc/profile'
+    sudo sh -c 'echo "export PATH=\${GOPATH}/bin:\${GOROOT}/bin:/usr/local/go/bin:\${PATH}" >> /etc/profile'
     cleantmp
 else
     echo "Skipping GO"


### PR DESCRIPTION
Escaped the lines: sudo sh -c 'echo "export PATH=\${GOPATH}/bin:\${GOROOT}/bin:/usr/local/go/bin:\${PATH}" >> /etc/profile' to avoid overwriting the PATH with the one was in the instant of running setup.